### PR TITLE
Update Lisk Delegates

### DIFF
--- a/lisk.yml
+++ b/lisk.yml
@@ -281,10 +281,9 @@ groups:
   -
     delegate: bitbanksy
     share: 60
-    requirements:
-      -
-        type: indexed
-        value: elite
+  -
+    delegate: bloqspace.io
+    share: 60
   -
     delegate: stellardynamic
     share: 40

--- a/lisk.yml
+++ b/lisk.yml
@@ -100,7 +100,6 @@ groups:
     tag: "ELT"
     class:
     members:
-
       - luiz
       - liskjp
       - iii.element.iii
@@ -119,7 +118,6 @@ groups:
       - xujian
       - eastwind_ja
       - mrgr
-      - luukas
       - crodam
       - hua
       - honeybee
@@ -152,7 +150,6 @@ groups:
       - threelittlepig
       - menfei
       - china
-#          - eely_delving
       - kaystar
       - elonhan
       - catstar

--- a/lisk.yml
+++ b/lisk.yml
@@ -162,7 +162,10 @@ groups:
       - liberspirita
       - robinhood
       - liskpro.com
-pools:
+      - bitbanksy
+      - 4fryn
+      - bloqspace.io
+    pools:
   -
     delegate: mars
     share: 75

--- a/lisk.yml
+++ b/lisk.yml
@@ -256,7 +256,7 @@ groups:
         - 17208736554155208523L
   -
     delegate: anamix
-    share: 60
+    share: 10
   -
     delegate: vi1son
     share: 40

--- a/lisk.yml
+++ b/lisk.yml
@@ -160,7 +160,7 @@ groups:
       - bitbanksy
       - 4fryn
       - bloqspace.io
-    pools:
+pools:
   -
     delegate: mars
     share: 75
@@ -873,7 +873,7 @@ groups:
     website: http://liskpoland.pl
   -
     delegate: 4fryn
-    share: 75
+    share: 60
     website: https://4fry.net
     payout:
       min: 1

--- a/lisk.yml
+++ b/lisk.yml
@@ -92,7 +92,6 @@ groups:
     class: md-warn
     members:
       - phoenix1969
-      - bitbanksy
       - stellardynamic
       - nerigal
   elite:
@@ -288,7 +287,7 @@ groups:
         value: elite
   -
     delegate: bitbanksy
-    share: 25
+    share: 60
     requirements:
       -
         type: indexed
@@ -429,7 +428,6 @@ groups:
   -
     delegate: kushed.delegate
     share: 40
-
   -
     delegate: hagie
     share: 40
@@ -439,12 +437,10 @@ groups:
   -
     delegate: ondin
     share: 25
-
   -
     delegate: sgdias
     share: 30
     website: http://lisk.com.ar
-
   -
     delegate: luiz
     share: 25
@@ -573,13 +569,6 @@ groups:
         value: elite
   -
     delegate: hua
-    share: 25
-    requirements:
-      -
-        type: indexed
-        value: elite
-  -
-    delegate: luukas
     share: 25
     requirements:
       -
@@ -798,14 +787,6 @@ groups:
       -
         type: indexed
         value: elite
-#  -
-#    delegate: eely_delving
-#    share: 25
-#        requirements:
-#          -
-#            type: indexed
-#            value: elite
-  -
     delegate: elonhan
     share: 25
     requirements:
@@ -837,12 +818,10 @@ groups:
     delegate: bioly
     share: 25
     website: http://pool.mylisk.com
-    
   -
     delegate: forrest
     share: 25
     website: http://lisk.forrestpool.win/
-    
   -
     delegate: samuray
     share: 50
@@ -855,7 +834,6 @@ groups:
   -
     delegate: slasheks
     share: 25
-    
   -
     delegate: index
     share: 25
@@ -874,28 +852,23 @@ groups:
     delegate: liskit
     share: 20
     website: http://liskit.me/
-    
   -
     delegate: fulig
     share: 20
   -
     delegate: joel
     share: 25
-    
   -
     delegate: dakk
     share: 15
     website: https://dakk.github.io/lisk-pool
-    
   -
     delegate: corsaro
     share: 10
     website: http://pool.liskworld.info/
-    
   -
     delegate: redsn0w
     share: 10
-    
   -
     delegate: splatters
     share: 10

--- a/lisk.yml
+++ b/lisk.yml
@@ -778,6 +778,7 @@ pools:
       -
         type: indexed
         value: elite
+  -
     delegate: elonhan
     share: 25
     requirements:


### PR DESCRIPTION
Update:
- Clean up formatting a bit
- Remove luukas from Elite
- Remove bitbanksy from Elite support
- Add new Sherwood delegates
- Update share for anamix (now in Ascend)
- Update share for 4fryn, bloqspace, and bitbanksy (now in Sherwood)

Bonus:
- Closes #99 