### PR TITLE
Update: ShiftTools delegate

### DIFF
--- a/shift.yml
+++ b/shift.yml
@@ -109,7 +109,7 @@ pools:
     share: 80
   -
     delegate: shift_tools
-    share: 35
+    share: 12
     website: https://shift-tools.com/pool.html
     notes: "Depending on the month, the payout is either a lottery that rewards with physical gifts, or a the entirety of the bounty."
     payout:

--- a/shift.yml
+++ b/shift.yml
@@ -110,7 +110,7 @@ pools:
   -
     delegate: shift_tools
     share: 12
-    website: https://shift-tools.com/pool.html
+    website: http://shift-tools.com/lottery.html
     notes: "Depending on the month, the payout is either a lottery that rewards with physical gifts, or a the entirety of the bounty."
     payout:
       schedule: monthly


### PR DESCRIPTION
- Shift Tools is back online ( http://shift-tools.com/lottery.html )
- Lowered Lottery payout percentage to 12%, since 35% does not make sense anymore

https://github.com/vekexasia/dpos-tools-data/issues/52